### PR TITLE
Update to newer versions of React and RXJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "webpack-rxjs-externals": "2.0.0"
   },
   "peerDependencies": {
-    "react": "16.x||17.x",
+    "react": "16.x||17.x||18.x",
     "rxjs": "^6.0.0"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "react": "16.x||17.x||18.x",
-    "rxjs": "^6.0.0"
+    "rxjs": "6.x||7.x"
   },
   "files": [
     "dist"


### PR DESCRIPTION
I've just updated the package.json peer dependencies values to make the great react-rxjs-elements library work with current versions. 
Performed serveral tests with React 18.0.0 and rxjs 7.5.5 and no bug was introduced. 